### PR TITLE
Use exit code 1 when invalid files are found

### DIFF
--- a/features/rails_erb_lint.feature
+++ b/features/rails_erb_lint.feature
@@ -7,6 +7,12 @@ Feature: Check validity of Rails ERB view files
     Then the exit status should be 0
     And the output should contain "A simple lint tool for ERB Rails views"
 
+  Scenario: Wheck check_validity option is called on valid views without arguments
+    Given I have only valid ERB files
+    When I check validity of ERB files in current directory
+    Then the output should contain "Checking for files in current directory"
+    And the output should contain "0 invalid files"
+
   Scenario: Wheck check_validity option is called on invalid views without arguments
     Given I have invalid ERB files
     When I check validity of ERB files in current directory

--- a/features/rails_erb_lint.feature
+++ b/features/rails_erb_lint.feature
@@ -13,7 +13,7 @@ Feature: Check validity of Rails ERB view files
     And the output should contain "2 files, 1 invalid file"
     And the output should not contain "valid.erb => valid"
 
-  Scenario: Wheck check_validity option is called on invalid views without arguments
+  Scenario: Wheck check_validity option is called on invalid views with the -v switch
     When I check validity of ERB files in current directory with -v switch
     Then the output should contain "Checking for files in current directory"
     And the output should contain "2 files, 1 invalid file"

--- a/features/rails_erb_lint.feature
+++ b/features/rails_erb_lint.feature
@@ -11,18 +11,21 @@ Feature: Check validity of Rails ERB view files
     Given I have only valid ERB files
     When I check validity of ERB files in current directory
     Then the output should contain "Checking for files in current directory"
-    And the output should contain "0 invalid files"
+    And the output should contain "1 files, no invalid file"
+    And the exit status should be 0
 
   Scenario: Wheck check_validity option is called on invalid views without arguments
     Given I have invalid ERB files
     When I check validity of ERB files in current directory
     Then the output should contain "Checking for files in current directory"
-    And the output should contain "2 files, 1 invalid file"
+    And the output should contain "1 invalid file"
     And the output should not contain "valid.erb => valid"
+    And the exit status should be 1
 
   Scenario: Wheck check_validity option is called on invalid views with the -v switch
     Given I have invalid ERB files
     When I check validity of ERB files in current directory with -v switch
     Then the output should contain "Checking for files in current directory"
-    And the output should contain "2 files, 1 invalid file"
+    And the output should contain "1 invalid file"
     And the output should contain "valid.erb => valid"
+    And the exit status should be 1

--- a/features/rails_erb_lint.feature
+++ b/features/rails_erb_lint.feature
@@ -8,12 +8,14 @@ Feature: Check validity of Rails ERB view files
     And the output should contain "A simple lint tool for ERB Rails views"
 
   Scenario: Wheck check_validity option is called on invalid views without arguments
+    Given I have invalid ERB files
     When I check validity of ERB files in current directory
     Then the output should contain "Checking for files in current directory"
     And the output should contain "2 files, 1 invalid file"
     And the output should not contain "valid.erb => valid"
 
   Scenario: Wheck check_validity option is called on invalid views with the -v switch
+    Given I have invalid ERB files
     When I check validity of ERB files in current directory with -v switch
     Then the output should contain "Checking for files in current directory"
     And the output should contain "2 files, 1 invalid file"

--- a/features/step_definitions/rails_erb_lint_steps.rb
+++ b/features/step_definitions/rails_erb_lint_steps.rb
@@ -1,21 +1,19 @@
-When /^I get help for "([^"]*)"$/ do |app_name|
-  @app_name = app_name
-  step %(I run `#{app_name} help`)
-end
-
-Then /^I copy files to the test directory$/ do
+Given(/^I have invalid ERB files$/) do
   source = Dir['./features/fixtures/app/views/*']
   dest = Dir['./tmp/aruba']
   FileUtils.cp_r(source, dest)
 end
 
+When /^I get help for "([^"]*)"$/ do |app_name|
+  @app_name = app_name
+  step %(I run `#{app_name} help`)
+end
+
 Then /^I check validity of ERB files in current directory$/ do
-  step %(I copy files to the test directory)
   step %(I run `rails-erb-lint check`)
 end
 
 Then /^I check validity of ERB files in current directory with -v switch$/ do
-  step %(I copy files to the test directory)
   step %(I run `rails-erb-lint check --verbose`)
 end
 

--- a/features/step_definitions/rails_erb_lint_steps.rb
+++ b/features/step_definitions/rails_erb_lint_steps.rb
@@ -1,3 +1,9 @@
+Given(/^I have only valid ERB files$/) do
+  source = Dir['./features/fixtures/app/views/valid.erb']
+  dest = Dir['./tmp/aruba/']
+  FileUtils.cp_r(source, dest)
+end
+
 Given(/^I have invalid ERB files$/) do
   source = Dir['./features/fixtures/app/views/*']
   dest = Dir['./tmp/aruba']

--- a/lib/rails-erb-lint/linter/check_validity.rb
+++ b/lib/rails-erb-lint/linter/check_validity.rb
@@ -37,7 +37,9 @@ command :check do |c|
       end
     end
 
-    puts "#{valid.size + invalid.size} files, #{invalid.size} invalid files".yellow
+    exit_now!("#{invalid.size} invalid files") if invalid.any?
+
+    puts "#{valid.size + invalid.size} files, no invalid files".yellow
   end
 end
 


### PR DESCRIPTION
So the CI server knows whether the run was successful or not.

I had to refactor the Cucumber specs a bit to test this feature.