### PR TITLE
Use Rainbow instead of Colorize

### DIFF
--- a/lib/rails-erb-lint/linter/check_validity.rb
+++ b/lib/rails-erb-lint/linter/check_validity.rb
@@ -1,7 +1,7 @@
 require 'gli'
 require 'action_view'
 require 'find'
-require 'colorize'
+require 'rainbow'
 
 require_relative '../helpers/rails_erb_check'
 
@@ -18,7 +18,7 @@ command :check do |c|
     erb_files = []
 
     path = Dir.getwd
-    puts "Checking for files in current directory: #{path}".green
+    puts Rainbow("Checking for files in current directory: #{path}").green
 
     Find.find(path.to_s) do |f|
       next if FileTest.directory?(f)
@@ -29,17 +29,17 @@ command :check do |c|
 
     erb_files.each do |f|
       if RailsErbCheck.valid_syntax?(File.read(f))
-        puts "#{f} => valid".green if options[:verbose]
+        puts Rainbow("#{f} => valid").green if options[:verbose]
         valid << f
       else
-        puts "#{f} => invalid".red
+        puts Rainbow("#{f} => invalid").red
         invalid << f
       end
     end
 
     exit_now!("#{invalid.size} invalid files") if invalid.any?
 
-    puts "#{valid.size + invalid.size} files, no invalid files".yellow
+    puts Rainbow("#{valid.size + invalid.size} files, no invalid files").yellow
   end
 end
 

--- a/rails-erb-lint.gemspec
+++ b/rails-erb-lint.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables << 'rails-erb-lint'
   s.add_development_dependency('rake')
   s.add_development_dependency('aruba')
-  s.add_dependency('colorize', '~> 0.7')
+  s.add_dependency('rainbow', '~> 2.0')
   s.add_dependency('actionpack', '~> 4.0')
   s.add_development_dependency('builder')
   s.add_dependency('gli','~> 2.1')


### PR DESCRIPTION
`Colorize` does monkey patching on the core class `String`, which is bad practice in my opinion.