### PR TITLE
Add JSON export, print-error mode, update help menus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ tags
 coverage
 rdoc
 pkg
+vendor
 
 ## PROJECT::SPECIFIC
 tmp

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ rails-erb-lint check
 ```
 
 By default, we don't show which files are valid as that makes little sense. 
-However you can show them through verbose mode.
+However you can show them through valid mode.
 
 ```bash
 cd your-rails-app/app/views

--- a/features/step_definitions/rails_erb_lint_steps.rb
+++ b/features/step_definitions/rails_erb_lint_steps.rb
@@ -20,7 +20,7 @@ Then /^I check validity of ERB files in current directory$/ do
 end
 
 Then /^I check validity of ERB files in current directory with -v switch$/ do
-  step %(I run `rails-erb-lint check --verbose`)
+  step %(I run `rails-erb-lint check --valid`)
 end
 
 Then /^the output should contain ([^"]*)"$/ do |output|

--- a/lib/rails-erb-lint/helpers/rails_erb_check.rb
+++ b/lib/rails-erb-lint/helpers/rails_erb_check.rb
@@ -1,13 +1,23 @@
 require 'action_view'
 
 module RailsErbCheck
-  def self.valid_syntax?(erb)
-    begin
-      ActionView::Template::Handlers::Erubis.new(erb).result
-    rescue SyntaxError
-      return false
-    rescue Exception
-      return true
+  class Checker
+    attr_reader :error
+
+    def initialize(erb_path)
+      @erb = File.read(erb_path)
     end
+
+    def valid_syntax?
+      begin
+        ActionView::Template::Handlers::Erubis.new(@erb).result
+      rescue SyntaxError => e
+        @error = e
+        return false
+      rescue Exception
+        return true
+      end
+    end
+
   end
 end

--- a/lib/rails-erb-lint/linter/check_validity.rb
+++ b/lib/rails-erb-lint/linter/check_validity.rb
@@ -2,6 +2,7 @@ require 'gli'
 require 'action_view'
 require 'find'
 require 'rainbow'
+require 'json'
 
 require_relative '../helpers/rails_erb_check'
 
@@ -9,31 +10,84 @@ include GLI::App
 
 program_desc 'A simple lint tool for ERB Rails views.'
 
+def get_erb_list(path)
+  erb_files = []
+
+  Find.find(path.to_s) do |f|
+    next if FileTest.directory?(f)
+    if /.*\.erb/.match(File.basename(f))
+      erb_files << f
+    end
+  end
+
+  erb_files
+end
+
+def check_files(erbs, options)
+  files = {}
+
+  erbs.each do |f|
+    checker = RailsErbCheck::Checker.new(f)
+
+    if checker.valid_syntax?
+      puts Rainbow("#{f} => valid").green if options[:valid]
+      files[f] = { invalid: false }
+    else
+      puts Rainbow("#{f} => invalid").red
+      puts checker.error.message if options[:error]
+      files[f] = {
+        invalid: true,
+        error: checker.error.message,
+        backtrace: checker.error.backtrace
+      }
+    end
+  end
+
+  files
+end
+
+def export_json(hash, path)
+  File.open(path, 'w') do |file|
+    JSON.dump(hash, file)
+  end
+end
+
 desc 'Check for syntax errors on views'
 command :check do |c|
-  c.switch :verbose, default_value: false
-  c.action do |global_options, options|
-    valid = []
-    invalid = []
-    erb_files = []
+  c.switch [:v, :valid], {
+    default_value: false,
+    arg_name: 'valid',
+    desc: 'print valid files along with invalid files'
+  }
 
+  c.switch [:e, :error], {
+    default_value: false,
+    arg_name: 'error',
+    desc: 'print errors associated with invalid files'
+  }
+
+  c.flag [:j, :json], {
+    default_value: nil,
+    arg_name: 'json-file',
+    type: String,
+    desc: 'Export a json file with results, also exports valid files when coupled with -v'
+  }
+
+  c.action do |global_options, options|
     path = Dir.getwd
     puts Rainbow("Checking for files in current directory: #{path}").green
 
-    Find.find(path.to_s) do |f|
-      next if FileTest.directory?(f)
-      if /.*\.erb/.match(File.basename(f))
-        erb_files << f
-      end
-    end
+    erbs  = get_erb_list(path)
+    files = check_files(erbs, options)
 
-    erb_files.each do |f|
-      if RailsErbCheck.valid_syntax?(File.read(f))
-        puts Rainbow("#{f} => valid").green if options[:verbose]
-        valid << f
+    valid   = files.reject { |file, info| info[:invalid] }
+    invalid = files.select { |file, info| info[:invalid] }
+
+    if options[:json]
+      if options[:valid]
+        export_json(files, options[:json])
       else
-        puts Rainbow("#{f} => invalid").red
-        invalid << f
+        export_json(invalid, options[:json])
       end
     end
 

--- a/lib/rails-erb-lint/linter/check_validity.rb
+++ b/lib/rails-erb-lint/linter/check_validity.rb
@@ -73,8 +73,15 @@ command :check do |c|
     desc: 'Export a json file with results, also exports valid files when coupled with -v'
   }
 
+  c.flag [:p, :path], {
+    default_value: Dir.getwd,
+    arg_name: 'path',
+    type: String,
+    desc: 'specify the path that should be used as the root of the check'
+  }
+
   c.action do |global_options, options|
-    path = Dir.getwd
+    path = options[:path]
     puts Rainbow("Checking for files in current directory: #{path}").green
 
     erbs  = get_erb_list(path)

--- a/lib/rails-erb-lint/version.rb
+++ b/lib/rails-erb-lint/version.rb
@@ -1,3 +1,3 @@
 module RailsErbLint
-  VERSION = '1.1.6'
+  VERSION = '1.2.0'
 end

--- a/rails-erb-lint.gemspec
+++ b/rails-erb-lint.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('aruba')
   s.add_dependency('rainbow', '~> 2.0')
   s.add_dependency('actionpack', '>= 4.0')
+  s.add_dependency('json')
   s.add_development_dependency('builder')
   s.add_dependency('gli','~> 2.1')
 end


### PR DESCRIPTION
These changes break using `--verbose` in favor of `--valid`, `-v` still works. The added functionality is as follows:

```
$ bin/rails-erb-lint check -e

Checking for files in current directory: /Users/rileyt/Development/3rd-party/rails-erb-lint
/Users/rileyt/Development/3rd-party/rails-erb-lint/features/fixtures/app/views/invalid2.erb => invalid
(erubis:3: syntax error, unexpected '<'
  <%= f.text_field :name );@output_buffer.safe_append='
   ^
(erubis:6: syntax error, unexpected end-of-input, expecting ')'
@output_buffer.to_s
                   ^
error: 1 invalid files
```

```
$ bin/rails-erb-lint check -j output.json

Checking for files in current directory: /Users/rileyt/Development/3rd-party/rails-erb-lint
/Users/rileyt/Development/3rd-party/rails-erb-lint/features/fixtures/app/views/invalid2.erb => invalid
error: 1 invalid files

$ cat output.json

{"/Users/rileyt/Development/3rd-party/rails-erb-lint/features/fixtures/app/views/invalid2.erb":{"invalid":true,"error":"(erubis:3: syntax error, unexpected '<'\n  <%= f.text_field :name );@output_buffer.safe_append='\n   ^\n(erubis:6: syntax error, unexpected end-of-input, expecting ')'\n@output_buffer.to_s\n                   ^","backtrace":["/Users/rileyt/Development/3rd-party/rails-erb-lint/vendor/bundle/ruby/2.2.0/gems/erubis-2.7.0/lib/erubis/evaluator.rb:65:in `eval'", ...]}}
```

```
$ bin/rails-erb-lint check -p features/fixtures -v

Checking for files in current directory: features/fixtures
features/fixtures/app/views/invalid2.erb => invalid
features/fixtures/app/views/valid.erb => valid
error: 1 invalid files
```