### PR TITLE
Compatibility with Rails 5.1 and Erubi

### DIFF
--- a/lib/rails-erb-lint/helpers/rails_erb_check.rb
+++ b/lib/rails-erb-lint/helpers/rails_erb_check.rb
@@ -2,6 +2,13 @@ require 'action_view'
 
 module RailsErbCheck
   class Checker
+    CHECKER =
+      if defined?(ActionView::Template::Handlers::ERB::Erubi)
+        ActionView::Template::Handlers::ERB::Erubi
+      else
+        ActionView::Template::Handlers::Erubis
+      end
+
     attr_reader :error
 
     def initialize(erb_path)
@@ -10,7 +17,7 @@ module RailsErbCheck
 
     def valid_syntax?
       begin
-        ActionView::Template::Handlers::Erubis.new(@erb).result
+        CHECKER.new(@erb).result
       rescue SyntaxError => e
         @error = e
         return false


### PR DESCRIPTION
Rails 5.1 is using Erubi instead of Erubis. See
https://github.com/rails/rails/blob/v5.1.0.beta1/actionview/lib/action_view/template/handlers/erb/deprecated_erubis.rb