### PR TITLE
Fix Erubi usage (Rails 5.1)

### DIFF
--- a/lib/rails-erb-lint/helpers/rails_erb_check.rb
+++ b/lib/rails-erb-lint/helpers/rails_erb_check.rb
@@ -4,9 +4,9 @@ module RailsErbCheck
   class Checker
     CHECKER =
       if defined?(ActionView::Template::Handlers::ERB::Erubi)
-        ActionView::Template::Handlers::ERB::Erubi
+        ->(erb) { eval ActionView::Template::Handlers::ERB::Erubi.new(erb).src }
       else
-        ActionView::Template::Handlers::Erubis
+        ->(erb) { ActionView::Template::Handlers::Erubis.new(erb).result }
       end
 
     attr_reader :error
@@ -17,7 +17,7 @@ module RailsErbCheck
 
     def valid_syntax?
       begin
-        CHECKER.new(@erb).result
+        CHECKER.call(@erb)
       rescue SyntaxError => e
         @error = e
         return false


### PR DESCRIPTION
It seems I was a bit too ~sloppy~ fast in #13: Erubi doesn't implement a `#result` method. The documentation at https://github.com/jeremyevans/erubi#usage explains how one must call `#src` on the generated object, and `eval` the result.

It works, and the tests will now again pass when using Rails 5.1.

Should we consider having Travis test against multiple versions of Rails?