### PR TITLE
Loosen version restriction of rainbow gem

### DIFF
--- a/rails-erb-lint.gemspec
+++ b/rails-erb-lint.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables << 'rails-erb-lint'
   s.add_development_dependency('rake')
   s.add_development_dependency('aruba')
-  s.add_dependency('rainbow', '~> 2.0')
+  s.add_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_dependency('actionpack', '>= 4.0')
   s.add_dependency('json')
   s.add_development_dependency('builder')


### PR DESCRIPTION
Rainbow 3.0.0 doesn’t have any breaking changes that affect us: https://github.com/sickill/rainbow/blob/master/Changelog.md#300-2017-11-29